### PR TITLE
Added the UIUserInterfaceIdiomWatch type

### DIFF
--- a/UIKit/Types.h
+++ b/UIKit/Types.h
@@ -197,6 +197,7 @@ PS_ENUM(NSInteger, UIUserInterfaceIdiom) {
     UIUserInterfaceIdiomPad,
     UIUserInterfaceIdiomTV,
     UIUserInterfaceIdiomCarPlay,
+    UIUserInterfaceIdiomWatch,
     UIUserInterfaceIdiomMac = 5,
 };
 


### PR DESCRIPTION
And just a heads up, I made sure to place the Watch enum under CarPlay as that’s the correct order. 

Example:
typedef NS_ENUM(NSInteger, UIUserInterfaceIdiom) {
    UIUserInterfaceIdiomUnspecified = -1,
    UIUserInterfaceIdiomPhone = 0,
    UIUserInterfaceIdiomPad = 1,
    UIUserInterfaceIdiomTV = 2,
    UIUserInterfaceIdiomCarPlay = 3,
    UIUserInterfaceIdiomWatch = 4
};